### PR TITLE
Created 2 Cogs lock and skip

### DIFF
--- a/cogs/control/lock.py
+++ b/cogs/control/lock.py
@@ -1,0 +1,21 @@
+import disnake
+from disnake.ext import commands
+from config import moderation_role_id, skip_role_id
+
+class LockCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.slash_command(description="Забрать доступ к приватным комнатам")
+    async def skip(self, inter: disnake.ApplicationCommandInteraction, user: disnake.Member):
+        if not any(role.id in moderation_role_id for role in inter.author.roles):
+            await inter.response.send_message("У вас нет доступа к этой команде.", ephemeral=True)
+            return
+
+        role = inter.guild.get_role(skip_role_id)
+        if not role:
+            return
+        await user.remove_roles(role)
+
+def setup(bot):
+    bot.add_cog(LockCog(bot))

--- a/cogs/control/skip.py
+++ b/cogs/control/skip.py
@@ -1,0 +1,21 @@
+import disnake
+from disnake.ext import commands
+from config import moderation_role_id, skip_role_id
+
+class SkipCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.slash_command(description="Выдать доступ к приватным комнатам")
+    async def skip(self, inter: disnake.ApplicationCommandInteraction, user: disnake.Member):
+        if not any(role.id in moderation_role_id for role in inter.author.roles):
+            await inter.response.send_message("У вас нет доступа к этой команде.", ephemeral=True)
+            return
+
+        role = inter.guild.get_role(skip_role_id)
+        if not role:
+            return
+        await user.add_roles(role)
+
+def setup(bot):
+    bot.add_cog(SkipCog(bot))

--- a/cogs/moderation/unmute.py
+++ b/cogs/moderation/unmute.py
@@ -33,4 +33,3 @@ class UnmuteCog(commands.Cog):
 
 def setup(bot):
     bot.add_cog(UnmuteCog(bot))
-

--- a/config.py
+++ b/config.py
@@ -1,1 +1,2 @@
 moderation_role_id = []
+skip_role_id = 1


### PR DESCRIPTION
Created 2 Cogs lock and skip

lock - removes a role from the config (the role on the server must be configured for display rights)

skip - issues the role from the config (the role on the server must be configured for display rights)

config has been changed 
added skip_role_id